### PR TITLE
🐛[CRITICAL] Fixing a typo causing editConfig to throw an error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"gpr": "node scripts/gpr.js",
 		"docs": "docgen --source src --custom docs/index.yml --output docs/docs.json"
 	},
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "A complete framework to facilitate the tracking of user voice time using discord.js",
 	"main": "index.js",
 	"repository": {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -318,7 +318,7 @@ class VoiceManager extends EventEmitter {
      */
     async editConfig(_guildId, _configData) {
         await writeFile(
-            this.options.storage,
+            this.options.configStorage,
             JSON.stringify(
                 this.configs.map((config) => config.data),
                 (_, v) => (typeof v === "bigint" ? serialize(v) : v)


### PR DESCRIPTION
This commit fixes a bug with the editConfig which fixes a bug where the editConfig function would throw an node.js error.